### PR TITLE
Check for GatewayType for methods that attempts to load "customsequences"

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.governance.api.common.dataobjects.GovernanceArtifact;
 import org.wso2.carbon.governance.api.generic.GenericArtifactManager;
 import org.wso2.carbon.governance.api.generic.dataobjects.GenericArtifact;
+import org.wso2.carbon.h2.osgi.utils.CarbonUtils;
 import org.wso2.carbon.registry.core.ActionConstants;
 import org.wso2.carbon.registry.core.Association;
 import org.wso2.carbon.registry.core.Collection;
@@ -64,6 +65,7 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -126,7 +128,20 @@ public abstract class AbstractAPIManager implements APIManager {
                 //load resources for each tenants.
                 APIUtil.loadloadTenantAPIRXT( tenantUserName, tenantId);
                 APIUtil.loadTenantAPIPolicy( tenantUserName, tenantId);
-                APIUtil.writeDefinedSequencesToTenantRegistry(tenantId);
+
+                //Check whether GatewayType is synapse before loading sequences into registry
+                String filePath =
+                        CarbonUtils.getCarbonHome() + File.separator + "repository" + File.separator + "conf" +
+                                File.separator + "api-manager.xml";
+
+                APIManagerConfiguration configuration = new APIManagerConfiguration();
+                configuration.load(filePath);
+                String gatewayType = configuration.getFirstProperty(APIConstants.API_GATEWAY_TYPE);
+
+                if (APIConstants.API_GATEWAY_TYPE_SYNAPSE.equalsIgnoreCase(gatewayType)) {
+                    APIUtil.writeDefinedSequencesToTenantRegistry(tenantId);
+                }
+
                 ServiceReferenceHolder.setUserRealm((UserRealm)(ServiceReferenceHolder.getInstance().
                         getRealmService().getTenantUserRealm(tenantId)));
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/observers/CommonConfigDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/observers/CommonConfigDeployer.java
@@ -26,10 +26,14 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerAnalyticsConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.h2.osgi.utils.CarbonUtils;
 import org.wso2.carbon.utils.AbstractAxis2ConfigurationContextObserver;
+
+import java.io.File;
 
 /**
  * This task provisions mandatory configs & Artifacts needed by any tenant. The reason for introducing this task is
@@ -53,7 +57,18 @@ public class CommonConfigDeployer extends AbstractAxis2ConfigurationContextObser
         }
 
         try {
-            APIUtil.writeDefinedSequencesToTenantRegistry(tenantId);
+            //Check whether GatewayType is synapse before loading sequences into registry
+            String filePath =
+                    CarbonUtils.getCarbonHome() + File.separator + "repository" + File.separator + "conf" +
+                            File.separator + "api-manager.xml";
+
+            APIManagerConfiguration configuration = new APIManagerConfiguration();
+            configuration.load(filePath);
+            String gatewayType = configuration.getFirstProperty(APIConstants.API_GATEWAY_TYPE);
+
+            if (APIConstants.API_GATEWAY_TYPE_SYNAPSE.equalsIgnoreCase(gatewayType)) {
+                APIUtil.writeDefinedSequencesToTenantRegistry(tenantId);
+            }
         }
         // Need to continue the execution even if we encounter an error.
         catch (Exception e) {


### PR DESCRIPTION
The calls for loading custom-sequences in the classes "AbstractAPIManager" and "CommonConfigDeployer", did not have the GatewayType check in the api-manager.xml file before attempting to load. This effects scenarios where the GatewayType configured is not "synapse".